### PR TITLE
[Fix] 빌드 파일에서 types 경로를 인식하지 못하는 문제 해결

### DIFF
--- a/packages/wow-ui/tsconfig.json
+++ b/packages/wow-ui/tsconfig.json
@@ -11,7 +11,7 @@
     "emitDeclarationOnly": true,
     "module": "ES2015",
     "moduleResolution": "Bundler",
-    "baseUrl": ".",
+    "baseUrl": "./src",
     "lib": ["es2022", "DOM", "DOM.Iterable"],
     "moduleDetection": "force",
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
## 🎉 변경 사항
`tsconfig`에서 `baseUrl`을 바꿔서
  - `dist/components/각 폴더` 요렇게가 아니라
  - `dist/각 폴더` 이런 식으로 빌드되도록 설정했더니 에러는 사라졌습니다.
  - 그러면 현재 스크립트 자동화해둔 대로 사용이 가능합니다.
    
    ```jsx
        "./TextField": {
          "types": "./dist/TextField/index.d.ts",
          "require": "./dist/TextField.cjs",
          "import": "./dist/TextField.js"
        }
    ```
 
  <img src="https://github.com/GDSC-Hongik/wow-design-system/assets/89445100/26e16fde-61c4-43e2-b791-d3c806ac3516" width="30%" />
  <img src="https://github.com/GDSC-Hongik/wow-design-system/assets/89445100/712396a7-9f16-413b-b8a6-de85c790a990" width="30%" />

## 🚩 관련 이슈

### 🙏 여기는 꼭 봐주세요!
이후 다른 라이브러리들 `dist` 어떻게 나오는지 살펴보고 빌드 스크립트 수정해도 좋을 것 같은데 어떻게 생각하시나요? `types` 폴더에서 관리한다든지, 컴포넌트마다 소스코드, 타입 폴더링한다든지..
