### PR TITLE
[Fix] : Checkbox 컴포넌트 pressed, cursor 관련 수정

### DIFF
--- a/packages/wow-ui/src/components/Checkbox/index.tsx
+++ b/packages/wow-ui/src/components/Checkbox/index.tsx
@@ -103,7 +103,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             aria-checked={checked}
             aria-disabled={disabled}
             aria-label={inputProps?.["aria-label"] ?? "checkbox"}
-            data-pressed={pressed || undefined}
+            {...(pressed && { "data-pressed": true })}
             id={id}
             ref={ref}
             tabIndex={0}

--- a/packages/wow-ui/src/components/Checkbox/index.tsx
+++ b/packages/wow-ui/src/components/Checkbox/index.tsx
@@ -103,7 +103,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             aria-checked={checked}
             aria-disabled={disabled}
             aria-label={inputProps?.["aria-label"] ?? "checkbox"}
-            data-pressed={pressed}
+            data-pressed={pressed || undefined}
             id={id}
             ref={ref}
             tabIndex={0}
@@ -148,6 +148,7 @@ const checkboxStyle = cva({
     alignItems: "center",
     outline: "none",
     position: "relative",
+    cursor: "inherit",
   },
   variants: {
     type: {


### PR DESCRIPTION
## 🎉 변경 사항
스토리북 살펴보다가 체크박스 수정해야될 부분이 있어 호다닥 수정해봅니당..

- pressed 상태일 때에만 data-pressed 값을 가지도록 수정합니다.
- input의 type 이 checkbox 일 때 무조건 cursor:default 가 들어가서 cursor: inherit 을 통해 label 에서 정한 cursor css 를 받을 수 있도록 수정합니다.

## 🚩 관련 이슈

### 🙏 여기는 꼭 봐주세요!
