### PR TITLE
[Fix] TextField, DropDown 컴포넌트의 디자인 수정

### DIFF
--- a/.changeset/smooth-beers-provide.md
+++ b/.changeset/smooth-beers-provide.md
@@ -1,0 +1,6 @@
+---
+"wowds-ui": patch
+---
+
+TextField 컴포넌트의 textarea 영역을 backgroundNormal 로 수정합니다.
+DropDown 에서 trigger 되는 부분의 focus 디자인을 수정합니다.

--- a/apps/wow-docs/styled-system/tokens/index.js
+++ b/apps/wow-docs/styled-system/tokens/index.js
@@ -343,6 +343,14 @@ const tokens = {
     value: 10,
     variable: "var(--z-index-dropdown)",
   },
+  "shadows.blue": {
+    value: "0px 4px 8px 0px rgba(16, 43, 74, 0.2)",
+    variable: "var(--shadows-blue)",
+  },
+  "shadows.mono": {
+    value: "0px 4px 8px 0px rgba(0, 0, 0, 0.2)",
+    variable: "var(--shadows-mono)",
+  },
   "breakpoints.sm": {
     value: "640px",
     variable: "var(--breakpoints-sm)",

--- a/apps/wow-docs/styled-system/tokens/tokens.d.ts
+++ b/apps/wow-docs/styled-system/tokens/tokens.d.ts
@@ -86,6 +86,8 @@ export type Token =
   | "borderWidths.button"
   | "borderWidths.arrow"
   | "zIndex.dropdown"
+  | "shadows.blue"
+  | "shadows.mono"
   | "breakpoints.sm"
   | "breakpoints.md"
   | "breakpoints.lg"
@@ -307,6 +309,8 @@ export type BorderWidthToken = "button" | "arrow";
 
 export type ZIndexToken = "dropdown";
 
+export type ShadowToken = "blue" | "mono";
+
 export type BreakpointToken = "sm" | "md" | "lg" | "xl" | "2xl";
 
 export type SizeToken =
@@ -323,6 +327,7 @@ export type Tokens = {
   radii: RadiusToken;
   borderWidths: BorderWidthToken;
   zIndex: ZIndexToken;
+  shadows: ShadowToken;
   breakpoints: BreakpointToken;
   sizes: SizeToken;
 } & { [token: string]: never };

--- a/apps/wow-docs/styled-system/types/prop-type.d.ts
+++ b/apps/wow-docs/styled-system/types/prop-type.d.ts
@@ -459,6 +459,7 @@ export interface UtilityValues {
   textDecorationColor: Tokens["colors"];
   textEmphasisColor: Tokens["colors"];
   textIndent: Tokens["spacing"];
+  textShadow: Tokens["shadows"];
   textShadowColor: Tokens["colors"];
   textWrap: "wrap" | "balance" | "nowrap";
   truncate: boolean;
@@ -522,6 +523,7 @@ export interface UtilityValues {
   borderBottomColor: Tokens["colors"];
   borderBlockEndColor: Tokens["colors"];
   borderBlockStartColor: Tokens["colors"];
+  boxShadow: Tokens["shadows"];
   boxShadowColor: Tokens["colors"];
   filter: "auto";
   backdropFilter: "auto";

--- a/apps/wow-docs/styled-system/types/style-props.d.ts
+++ b/apps/wow-docs/styled-system/types/style-props.d.ts
@@ -1976,7 +1976,12 @@ export interface SystemProperties {
    *
    * @see https://developer.mozilla.org/docs/Web/CSS/box-shadow
    */
-  boxShadow?: ConditionalValue<CssProperties["boxShadow"] | AnyString>;
+  boxShadow?: ConditionalValue<
+    | UtilityValues["boxShadow"]
+    | CssVars
+    | CssProperties["boxShadow"]
+    | AnyString
+  >;
   /**
    * The **`box-sizing`** CSS property sets how the total width and height of an element is calculated.
    *
@@ -6572,7 +6577,12 @@ export interface SystemProperties {
    *
    * @see https://developer.mozilla.org/docs/Web/CSS/text-shadow
    */
-  textShadow?: ConditionalValue<CssProperties["textShadow"] | AnyString>;
+  textShadow?: ConditionalValue<
+    | UtilityValues["textShadow"]
+    | CssVars
+    | CssProperties["textShadow"]
+    | AnyString
+  >;
   /**
    * The **`text-size-adjust`** CSS property controls the text inflation algorithm used on some smartphones and tablets. Other browsers will ignore this property.
    *
@@ -8635,7 +8645,12 @@ export interface SystemProperties {
    *
    * @see https://developer.mozilla.org/docs/Web/CSS/box-shadow
    */
-  shadow?: ConditionalValue<CssProperties["boxShadow"] | AnyString>;
+  shadow?: ConditionalValue<
+    | UtilityValues["boxShadow"]
+    | CssVars
+    | CssProperties["boxShadow"]
+    | AnyString
+  >;
   shadowColor?: ConditionalValue<
     UtilityValues["boxShadowColor"] | CssVars | AnyString
   >;

--- a/packages/wow-ui/src/components/DropDown/index.tsx
+++ b/packages/wow-ui/src/components/DropDown/index.tsx
@@ -187,6 +187,7 @@ const DropDown = ({
       cursor="pointer"
       direction="column"
       gap="xs"
+      outline="none"
       position="relative"
       ref={dropdownRef}
       tabIndex={0}

--- a/packages/wow-ui/src/components/TextField/index.tsx
+++ b/packages/wow-ui/src/components/TextField/index.tsx
@@ -277,6 +277,7 @@ const textareaStyle = cva({
     maxHeight: "7.5rem",
     overflowY: "hidden",
     resize: "none",
+    backgroundColor: "backgroundNormal",
     _placeholder: {
       color: "outline",
     },

--- a/packages/wow-ui/styled-system/tokens/index.js
+++ b/packages/wow-ui/styled-system/tokens/index.js
@@ -343,6 +343,14 @@ const tokens = {
     value: 10,
     variable: "var(--z-index-dropdown)",
   },
+  "shadows.blue": {
+    value: "0px 4px 8px 0px rgba(16, 43, 74, 0.2)",
+    variable: "var(--shadows-blue)",
+  },
+  "shadows.mono": {
+    value: "0px 4px 8px 0px rgba(0, 0, 0, 0.2)",
+    variable: "var(--shadows-mono)",
+  },
   "breakpoints.xs": {
     value: "360px",
     variable: "var(--breakpoints-xs)",

--- a/packages/wow-ui/styled-system/tokens/tokens.d.ts
+++ b/packages/wow-ui/styled-system/tokens/tokens.d.ts
@@ -86,6 +86,8 @@ export type Token =
   | "borderWidths.button"
   | "borderWidths.arrow"
   | "zIndex.dropdown"
+  | "shadows.blue"
+  | "shadows.mono"
   | "breakpoints.xs"
   | "breakpoints.sm"
   | "breakpoints.md"
@@ -305,6 +307,8 @@ export type BorderWidthToken = "button" | "arrow";
 
 export type ZIndexToken = "dropdown";
 
+export type ShadowToken = "blue" | "mono";
+
 export type BreakpointToken = "xs" | "sm" | "md" | "lg";
 
 export type SizeToken =
@@ -320,6 +324,7 @@ export type Tokens = {
   radii: RadiusToken;
   borderWidths: BorderWidthToken;
   zIndex: ZIndexToken;
+  shadows: ShadowToken;
   breakpoints: BreakpointToken;
   sizes: SizeToken;
 } & { [token: string]: never };

--- a/packages/wow-ui/styled-system/types/conditions.d.ts
+++ b/packages/wow-ui/styled-system/types/conditions.d.ts
@@ -2,7 +2,7 @@
 import type { AnySelector, Selectors } from "./selectors";
 
 export interface Conditions {
-  /** `&:is(:hover, [data-hover])` */
+  /** `&[aria-pressed=false]:not(:disabled):hover` */
   _hover: string;
   /** `&:is(:focus, [data-focus])` */
   _focus: string;

--- a/packages/wow-ui/styled-system/types/prop-type.d.ts
+++ b/packages/wow-ui/styled-system/types/prop-type.d.ts
@@ -459,6 +459,7 @@ export interface UtilityValues {
   textDecorationColor: Tokens["colors"];
   textEmphasisColor: Tokens["colors"];
   textIndent: Tokens["spacing"];
+  textShadow: Tokens["shadows"];
   textShadowColor: Tokens["colors"];
   textWrap: "wrap" | "balance" | "nowrap";
   truncate: boolean;
@@ -522,6 +523,7 @@ export interface UtilityValues {
   borderBottomColor: Tokens["colors"];
   borderBlockEndColor: Tokens["colors"];
   borderBlockStartColor: Tokens["colors"];
+  boxShadow: Tokens["shadows"];
   boxShadowColor: Tokens["colors"];
   filter: "auto";
   backdropFilter: "auto";

--- a/packages/wow-ui/styled-system/types/style-props.d.ts
+++ b/packages/wow-ui/styled-system/types/style-props.d.ts
@@ -1976,7 +1976,12 @@ export interface SystemProperties {
    *
    * @see https://developer.mozilla.org/docs/Web/CSS/box-shadow
    */
-  boxShadow?: ConditionalValue<CssProperties["boxShadow"] | AnyString>;
+  boxShadow?: ConditionalValue<
+    | UtilityValues["boxShadow"]
+    | CssVars
+    | CssProperties["boxShadow"]
+    | AnyString
+  >;
   /**
    * The **`box-sizing`** CSS property sets how the total width and height of an element is calculated.
    *
@@ -6572,7 +6577,12 @@ export interface SystemProperties {
    *
    * @see https://developer.mozilla.org/docs/Web/CSS/text-shadow
    */
-  textShadow?: ConditionalValue<CssProperties["textShadow"] | AnyString>;
+  textShadow?: ConditionalValue<
+    | UtilityValues["textShadow"]
+    | CssVars
+    | CssProperties["textShadow"]
+    | AnyString
+  >;
   /**
    * The **`text-size-adjust`** CSS property controls the text inflation algorithm used on some smartphones and tablets. Other browsers will ignore this property.
    *
@@ -8635,7 +8645,12 @@ export interface SystemProperties {
    *
    * @see https://developer.mozilla.org/docs/Web/CSS/box-shadow
    */
-  shadow?: ConditionalValue<CssProperties["boxShadow"] | AnyString>;
+  shadow?: ConditionalValue<
+    | UtilityValues["boxShadow"]
+    | CssVars
+    | CssProperties["boxShadow"]
+    | AnyString
+  >;
   shadowColor?: ConditionalValue<
     UtilityValues["boxShadowColor"] | CssVars | AnyString
   >;


### PR DESCRIPTION
## 🎉 변경 사항
- TextField 의 textarea 영역이 white 여야 해서 bg color 를 추가합니다.
![image](https://github.com/GDSC-Hongik/wow-design-system/assets/101736358/d05141a8-b8d4-4d8f-90f3-eb92b220a1e4)
- DropDown 의 트리거 영역의 outline none 을 추가합니다.

## 🚩 관련 이슈

### 🙏 여기는 꼭 봐주세요!
