### PR TITLE
[Feature] Close Icon 생성 및 배포 

### DIFF
--- a/.changeset/.grumpy-llamas-occur.md
+++ b/.changeset/.grumpy-llamas-occur.md
@@ -2,4 +2,4 @@
 "wowds-icons": patch
 ---
 
-help 아이콘을 패키지에 포함하여 helpIcon을 배포합니다.
+close 아이콘을 패키지에 포함하여 closeIcon을 배포합니다.

--- a/.changeset/.grumpy-llamas-occur.md
+++ b/.changeset/.grumpy-llamas-occur.md
@@ -1,5 +1,0 @@
----
-"wowds-icons": patch
----
-
-close 아이콘을 패키지에 포함하여 closeIcon을 배포합니다.

--- a/.changeset/grumpy-llamas-occur.md
+++ b/.changeset/grumpy-llamas-occur.md
@@ -1,0 +1,5 @@
+---
+"wowds-icons": patch
+---
+
+close 아이콘을 패키지에 포함하여 closeIcon을 배포합니다. 또한, 이전에 changelog에 포함되었지 않았던 helpIcon(pr[#73](https://github.com/GDSC-Hongik/wow-design-system/pull/73))을 함께 배포합니다.

--- a/.changeset/late-numbers-repair.md
+++ b/.changeset/late-numbers-repair.md
@@ -1,0 +1,5 @@
+---
+"wowds-icons": minor
+---
+
+close Icon을 배포해요.

--- a/packages/wow-icons/package.json
+++ b/packages/wow-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wowds-icons",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/wow-icons/src/component/Close.tsx
+++ b/packages/wow-icons/src/component/Close.tsx
@@ -1,0 +1,52 @@
+import { forwardRef } from "react";
+import { color } from "wowds-tokens";
+
+import type { IconProps } from "@/types/Icon.ts";
+
+const Close = forwardRef<SVGSVGElement, IconProps>(
+  (
+    {
+      className,
+      width = "24",
+      height = "24",
+      viewBox = "0 0 24 24",
+      stroke = "white",
+      ...rest
+    },
+    ref
+  ) => {
+    return (
+      <svg
+        aria-label="close icon"
+        className={className}
+        fill="none"
+        height={height}
+        ref={ref}
+        viewBox={viewBox}
+        width={width}
+        xmlns="http://www.w3.org/2000/svg"
+        {...rest}
+      >
+        <g id="&#235;&#139;&#171;&#234;&#184;&#176;">
+          <path
+            d="M19 20L12 12L19 4"
+            id="Vector 499"
+            stroke={color[stroke]}
+            strokeLinejoin="bevel"
+            strokeWidth="1.4"
+          />
+          <path
+            d="M5 4L12 12L5 20"
+            id="Vector 500"
+            stroke={color[stroke]}
+            strokeLinejoin="bevel"
+            strokeWidth="1.4"
+          />
+        </g>
+      </svg>
+    );
+  }
+);
+
+Close.displayName = "Close";
+export default Close;

--- a/packages/wow-icons/src/component/index.ts
+++ b/packages/wow-icons/src/component/index.ts
@@ -1,4 +1,5 @@
 export { default as Check } from "./Check.tsx";
+export { default as Close } from "./Close.tsx";
 export { default as DownArrow } from "./DownArrow.tsx";
 export { default as Help } from "./Help.tsx";
 export { default as RightArrow } from "./RightArrow.tsx";

--- a/packages/wow-icons/src/svg/close.svg
+++ b/packages/wow-icons/src/svg/close.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="&#235;&#139;&#171;&#234;&#184;&#176;">
+<path id="Vector 499" d="M19 20L12 12L19 4" stroke="#C2C2C2" stroke-width="1.4" stroke-linejoin="bevel"/>
+<path id="Vector 500" d="M5 4L12 12L5 20" stroke="#C2C2C2" stroke-width="1.4" stroke-linejoin="bevel"/>
+</g>
+</svg>


### PR DESCRIPTION
## 🎉 변경 사항
close Icon을 생성하고 배포해요.
아래 액션시트에서 필요해서 배포해두어요~ 
<img width="292" alt="스크린샷 2024-07-07 오전 1 28 06" src="https://github.com/GDSC-Hongik/wow-design-system/assets/67894159/04240caf-96cf-4f22-b5e2-2fbc24d98873">

### 🙏 여기는 꼭 봐주세요!
지난 Help 아이콘을 changeset을 제대로 사용하지 못하고 0.0.4로 수동 배포해버려서 이번에 아예 package.json 잘못된 부분 바로잡아서 changeset 파일과 함께 올립니다 ㅠㅠ 
`0.0.3 -> 0.0.4`로 변화시킨 부분 package.json에 작성함.