### PR TITLE
[Refactor] Stepper css 에러 해결, TextField border 스타일 적용 

### DIFF
--- a/.changeset/kind-worms-bathe.md
+++ b/.changeset/kind-worms-bathe.md
@@ -1,0 +1,6 @@
+---
+"wowds-ui": patch
+---
+
+- Stepper의 CSS 에러를 개선합니다. (마지막 글자 잘림 현상 및 border Style 적용 안됨 이슈 해결)
+- Textfield의 border Style이 적용 안되는 이슈를 해결합니다.

--- a/packages/wow-ui/src/components/Stepper/index.tsx
+++ b/packages/wow-ui/src/components/Stepper/index.tsx
@@ -126,6 +126,7 @@ const stepperCircleStyle = cva({
     position: "absolute",
     width: "1.5rem",
     borderWidth: "1px",
+    borderStyle: "solid",
     transform: "translateX(-50%)",
   },
   variants: {
@@ -169,6 +170,8 @@ const StepperLabel = ({
       transform="translateX(-50%)"
       style={{
         left: `${calcPercent(maxStep, value - 1)}%`,
+        bottom: "-35px",
+        whiteSpace: "nowrap",
       }}
     >
       <styled.span

--- a/packages/wow-ui/src/components/TextField/index.tsx
+++ b/packages/wow-ui/src/components/TextField/index.tsx
@@ -270,6 +270,7 @@ const textareaStyle = cva({
   base: {
     borderRadius: "sm",
     borderWidth: "button",
+    borderStyle: "solid",
     paddingX: "sm",
     paddingY: "xs",
     textStyle: "body1",


### PR DESCRIPTION
## 🎉 변경 사항
1. 프로덕션 환경에 배포하면 Stepper의 label의 마지막 글자가 잘려 보이는 현상이 있어 개선했어요.
2. TextField 및 Stepper에서 borderStyle이 solid로 적용되어 있지 않아서 스타일이 씹히는 현상을 개선해요.

## 🚩 관련 이슈
#81 
위 이슈에서 더욱 자세한 이야기를 확인할 수 있어요
### 🙏 여기는 꼭 봐주세요!
@ghdtjgus76 Textfield관련한 border 고쳐 두었어용~
