### PR TITLE
[Bug] TextField 컴포넌트 style, className 속성 가장 바깥 태그에서 관리하도록 수정

### DIFF
--- a/.changeset/poor-comics-hope.md
+++ b/.changeset/poor-comics-hope.md
@@ -1,0 +1,5 @@
+---
+"wowds-ui": patch
+---
+
+TextField 컴포넌트 style, className 속성을 적용할 수 있도록 수정합니다.

--- a/apps/wow-docs/app/page.tsx
+++ b/apps/wow-docs/app/page.tsx
@@ -1,4 +1,3 @@
-import Box from "wowds-ui/Box";
 import Checkbox from "wowds-ui/Checkbox";
 import Chip from "wowds-ui/Chip";
 import Divider from "wowds-ui/Divider";

--- a/packages/wow-ui/src/components/TextField/index.tsx
+++ b/packages/wow-ui/src/components/TextField/index.tsx
@@ -122,7 +122,7 @@ const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
     };
 
     return (
-      <Flex className={containerStyle()} direction="column" gap="xs">
+      <Flex className={containerStyle()} direction="column" gap="xs" {...rest}>
         <Flex alignItems="flex-end" justifyContent="space-between">
           <Label textareaId={descriptionId} variant={variant}>
             {label}
@@ -150,7 +150,6 @@ const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
           onBlur={handleBlur}
           onChange={handleChange}
           onFocus={handleFocus}
-          {...rest}
         />
         {helperText && <HelperText variant={variant}>{helperText}</HelperText>}
       </Flex>


### PR DESCRIPTION
## 🎉 변경 사항
TextField 컴포넌트 style, className 속성을 가장 바깥 태그에서 관리하도록 수정하였습니다.

유진님이 아래 사항 제보해주셔서 textarea 쪽에 적용했던 style, className 속성을 가장 바깥 태그에 적용하도록 수정했습니다.
https://github.com/GDSC-Hongik/gdsc-client/pull/74

## 🚩 관련 이슈
- #114 

### 🙏 여기는 꼭 봐주세요!
