### PR TITLE
[Fix] disabled 버튼 이벤트 막기

### DIFF
--- a/packages/wow-ui/src/components/Button/Button.stories.tsx
+++ b/packages/wow-ui/src/components/Button/Button.stories.tsx
@@ -170,3 +170,10 @@ export const LinkButton: Story = {
     href: "/",
   },
 };
+
+export const DisabledButton: Story = {
+  args: {
+    children: "버튼",
+    disabled: true,
+  },
+};

--- a/packages/wow-ui/src/components/Button/index.tsx
+++ b/packages/wow-ui/src/components/Button/index.tsx
@@ -119,7 +119,7 @@ const ButtonStyle = cva({
         _disabled: {
           background: "monoBackgroundPressed",
           color: "outline",
-          cursor: "not-allowed",
+          pointerEvents: "none",
         },
         _hover: {
           shadow: "blue",

--- a/packages/wow-ui/src/components/Button/index.tsx
+++ b/packages/wow-ui/src/components/Button/index.tsx
@@ -33,11 +33,6 @@ export interface CustomButtonProps {
   size?: "lg" | "sm";
   variant?: "solid" | "outline" | "sub";
   icon?: ReactNode;
-  onKeyUp?: () => void;
-  onKeyDown?: () => void;
-  onMouseLeave?: () => void;
-  onPointerDown?: () => void;
-  onPointerUp?: () => void;
   style?: CSSProperties;
   className?: string;
 }


### PR DESCRIPTION
## 🎉 변경 사항
- `disabled` 버튼 이벤트를 막습니다.

## 🚩 관련 이슈
- #151 

### 🙏 여기는 꼭 봐주세요!
- `disabled` 속성이 항상 동작하는 것이 아니라서 생긴 문제였습니다. (태그 종류에 따라 다름)
- `type: "button"`을 주는 방법도 있었으나, 버튼이 다른 역할을 할 수도 있는데 `type: "button"`을 강제하는 것보다는 `css` 속성으로 막아주는 것이 나을 것이라고 판단해 수정했습니다.