### PR TITLE
[Fix] : Table 컴포넌트의 상위 context가 존재하지 않아도 useContext 에러가 발생하지 않도록 수정해요.

### DIFF
--- a/.changeset/eighty-cheetahs-kiss.md
+++ b/.changeset/eighty-cheetahs-kiss.md
@@ -1,0 +1,5 @@
+---
+"wowds-ui": patch
+---
+
+Table 컴포넌트의 context 문제를 해결해요

--- a/packages/wow-ui/src/components/Table/Table.stories.tsx
+++ b/packages/wow-ui/src/components/Table/Table.stories.tsx
@@ -94,7 +94,7 @@ export const Primary: Story = {
         <Table.Tbody>
           {data.map(({ name, studyId, id }) => {
             return (
-              <Table.Tr key={id} value={id}>
+              <Table.Tr key={id}>
                 <Table.Td>{name}</Table.Td>
                 <Table.Td>{studyId}</Table.Td>
               </Table.Tr>

--- a/packages/wow-ui/src/components/Table/TableContext.ts
+++ b/packages/wow-ui/src/components/Table/TableContext.ts
@@ -1,8 +1,7 @@
 import type { Dispatch } from "react";
-import { createContext } from "react";
+import { createContext, useContext } from "react";
 
 import type { TableProps } from "@/components/Table/Table";
-import useSafeContext from "@/hooks/useSafeContext";
 import type useTableCheckState from "@/hooks/useTableCheckState";
 
 export const TableContext = createContext<
@@ -15,8 +14,20 @@ export const TableContext = createContext<
 >(null);
 
 export const useTableContext = () => {
-  const context = useSafeContext(TableContext);
-  return context;
+  const context = useContext(TableContext);
+  if (!context)
+    return {
+      selectedRows: new Set<number>(),
+      showCheckbox: false,
+      rowValues: new Set<number>(),
+      handleRowCheckboxChange: () => {},
+      handleHeaderCheckboxChange: () => {},
+      setRowValues: () => {},
+      rowValue: 0,
+    };
+  else {
+    return context;
+  }
 };
 
 export const TableCheckedContext = createContext<number | undefined>(0);

--- a/packages/wow-ui/src/components/Table/TableContext.ts
+++ b/packages/wow-ui/src/components/Table/TableContext.ts
@@ -23,7 +23,6 @@ export const useTableContext = () => {
       handleRowCheckboxChange: () => {},
       handleHeaderCheckboxChange: () => {},
       setRowValues: () => {},
-      rowValue: 0,
     };
   else {
     return context;

--- a/packages/wow-ui/src/components/Table/TableContext.ts
+++ b/packages/wow-ui/src/components/Table/TableContext.ts
@@ -24,9 +24,7 @@ export const useTableContext = () => {
       handleHeaderCheckboxChange: () => {},
       setRowValues: () => {},
     };
-  else {
-    return context;
-  }
+  return context;
 };
 
 export const TableCheckedContext = createContext<number | undefined>(0);

--- a/packages/wow-ui/src/components/Table/Td.tsx
+++ b/packages/wow-ui/src/components/Table/Td.tsx
@@ -1,13 +1,12 @@
 import { cva } from "@styled-system/css";
 import { styled } from "@styled-system/jsx";
 import type { CSSProperties, PropsWithChildren, Ref } from "react";
-import { forwardRef } from "react";
+import { forwardRef, useContext, useEffect, useState } from "react";
 
 import {
   TableCheckedContext,
   useTableContext,
 } from "@/components/Table/TableContext";
-import useSafeContext from "@/hooks/useSafeContext";
 
 interface TableCellProps extends PropsWithChildren {
   style?: CSSProperties;
@@ -18,8 +17,15 @@ const Td = forwardRef(
   (props: TableCellProps, ref: Ref<HTMLTableCellElement>) => {
     const { children, ...rest } = props;
     const { selectedRows } = useTableContext();
-    const rowValue = useSafeContext(TableCheckedContext);
-    const isSelected = selectedRows.has(rowValue);
+    const [isSelected, setIsSelected] = useState(false);
+
+    const rowValue = useContext(TableCheckedContext);
+    useEffect(() => {
+      if (rowValue) {
+        const value = selectedRows.has(rowValue);
+        setIsSelected(value);
+      }
+    }, [rowValue, selectedRows]);
 
     return (
       <styled.td


### PR DESCRIPTION
## 🎉 변경 사항
Table 컴포넌트에서 `useSafeContext` 훅을 사용하고 있었는데, 상위 컨텍스트가 존재하지 않으면 Error를 throw하는 로직을 갖고 있었어요.
Table 컴포넌트는 `checkbox`로직을 사용하지 않으면 context를 사용하지 않을 수도 있어요..!!
이를 보완하기 위하여 `useSafeContext`를 사용하는 대신, `context`가 null 일때, 기본 객체 값을 리턴할 수 있도록 하여
Context를 사용하던 사용하지 않던 에러가 발생하지 않도록 했어요.

## 🚩 관련 이슈
#173 

### 🙏 여기는 꼭 봐주세요!
@hamo-o 
이제 와우 클래스에서 불필요하게 Table 컨텍스트로 감쌌던 로직을 제거해도 문제가 생기지 않을 거예요.
