### PR TITLE
[Fix] Box 컴포넌트 disabled text color 변경

### DIFF
--- a/.changeset/curly-boats-mix.md
+++ b/.changeset/curly-boats-mix.md
@@ -1,0 +1,5 @@
+---
+"wowds-ui": patch
+---
+
+disabled box 배경색 변경

--- a/.changeset/red-houses-dream.md
+++ b/.changeset/red-houses-dream.md
@@ -1,0 +1,5 @@
+---
+"wowds-ui": patch
+---
+
+Box 컴포넌트 disabled text 컬러 변경

--- a/packages/wow-ui/src/components/Box/index.tsx
+++ b/packages/wow-ui/src/components/Box/index.tsx
@@ -97,14 +97,14 @@ const Box = <T extends BoxVariantType = "text">({
         {leftElement}
         <Flex direction="column" gap="xxs" width="100%">
           <styled.div
-            color={textColor ? textColor : "textBlack"}
+            color={textColor ? textColor : disabled ? "sub" : "textBlack"}
             width="100%"
             {...(typeof text === "string" && { textStyle: "h3" })}
           >
             {text}
           </styled.div>
           <styled.div
-            color={subTextColor ? subTextColor : "sub"}
+            color={subTextColor ? subTextColor : disabled ? "mono.600" : "sub"}
             textStyle="body1"
             width="100%"
           >

--- a/packages/wow-ui/src/components/Box/index.tsx
+++ b/packages/wow-ui/src/components/Box/index.tsx
@@ -166,6 +166,7 @@ const containerStyle = cva({
       },
       disabled: {
         borderColor: "lightDisabled",
+        backgroundColor: "backgroundAlternative",
       },
     },
 


### PR DESCRIPTION
## 🎉 변경 사항
Box 컴포넌트의 text color의 색이 와우 온보딩의 톤과 맞지 않아서 수정합니다.

### 🙏 여기는 꼭 봐주세요!
<img width="598" alt="스크린샷 2025-02-25 오전 12 06 42" src="https://github.com/user-attachments/assets/f873b2d4-647c-4f44-ba7d-fcda5fe27a9f" />
