### PR TITLE
[Feat] DropDown aria hidden  속성 제거

### DIFF
--- a/.changeset/thick-penguins-bake.md
+++ b/.changeset/thick-penguins-bake.md
@@ -1,0 +1,5 @@
+---
+"wowds-ui": patch
+---
+
+DropDown 의 aria hidden 속성을 제거합니다.

--- a/packages/wow-ui/src/components/DropDown/DropDown.test.tsx
+++ b/packages/wow-ui/src/components/DropDown/DropDown.test.tsx
@@ -74,8 +74,8 @@ describe("DropDown component", () => {
     await userEvent.click(document.body);
 
     await waitFor(() => {
-      const dropdown = screen.queryByRole("listbox");
-      expect(dropdown).toBeNull();
+      const dropdown = screen.queryByRole("combobox");
+      expect(dropdown).toHaveAttribute("aria-expanded", "true");
     });
   });
 });

--- a/packages/wow-ui/src/components/DropDown/DropDown.test.tsx
+++ b/packages/wow-ui/src/components/DropDown/DropDown.test.tsx
@@ -75,7 +75,7 @@ describe("DropDown component", () => {
 
     await waitFor(() => {
       const dropdown = screen.queryByRole("combobox");
-      expect(dropdown).toHaveAttribute("aria-expanded", "true");
+      expect(dropdown).toHaveAttribute("aria-expanded", "false");
     });
   });
 });

--- a/packages/wow-ui/src/components/DropDown/DropDownOptionList.tsx
+++ b/packages/wow-ui/src/components/DropDown/DropDownOptionList.tsx
@@ -64,12 +64,11 @@ const DropDownOptionList = ({
 
   return (
     <styled.ul
-      aria-hidden={!open}
       aria-labelledby={`${dropdownId}-trigger`}
       id={`${dropdownId}-option-list`}
       ref={listRef}
       role="listbox"
-      tabIndex={0}
+      tabIndex={-1}
       visibility={open ? "visible" : "hidden"}
       className={dropdownContentStyle({
         type: hasCustomTrigger ? "custom" : "default",


### PR DESCRIPTION
## 🎉 변경 사항
![image](https://github.com/user-attachments/assets/143c4e44-eae2-4c5c-aafc-a1468c6beade)
- 드롭다운에 aria hidden 관련 에러가 있어 hidden 속성을 제거합니다. ([aria 문서](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/)에서도 hidden 관련 권장사항은 없음)

## 🚩 관련 이슈
- 드롭다운을 사용하는 wow-class 에서 에러 발생 중입니다,

### 🙏 여기는 꼭 봐주세요!
